### PR TITLE
Updated logging to use gutil

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-run-electron",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Gulp plugin for starting Electron.",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ function spawn(cb)
 	{
 		var str = data.toString().trim();
 		if (str)
-			console.log("[electron] " + str);
+			gutil.log("[electron] " + str);
 	}
 
 	child.stdout.on("data", print);


### PR DESCRIPTION
gulp-util has a slightly nicer looking logging mechanism that conforms with the look of other gulp messages. easy switch over from console.log to gutil.log
