### PR TITLE
Migrate from electron prebuilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gulp-run-electron
 Gulp plugin for starting Electron.
-Requires a peer dependency of `electron-prebuilt`.
+Requires a peer dependency of `electron`.
 
 ## Usage
 ```js

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "through2": "^2.0.1"
   },
   "peerDependencies": {
-    "electron-prebuilt": "*"
+    "electron": "*"
   },
   "devDependencies": {
     "gulp": "^3.9.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-run-electron",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Gulp plugin for starting Electron.",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 var through = require("through2");
-var electron = require("electron-prebuilt");
+var electron = require("electron");
 var gutil = require("gulp-util");
 var proc = require("child_process");
 


### PR DESCRIPTION
Migration from `electron-prebuilt` peer dependency to `electron`. Fixes #5
