### PR TITLE
Fix environment on linux

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,15 @@ function spawn(cb)
 		return;
 	}
 
+	// Layer environment over existing environment (for linux)
+	if (opts.env) {
+		var env = process.env;
+		for (var key in opts.env) {
+			env[key] = opts.env[key];
+		}
+		opts.env = env;
+	}
+
 	child = proc.spawn(electron, args.concat(file.path), opts);
 
 	child.on("error", function(err)

--- a/src/index.js
+++ b/src/index.js
@@ -29,11 +29,11 @@ function spawn(cb)
 
 	// Layer environment over existing environment (for linux)
 	if (opts.env) {
-		var env = process.env;
-		for (var key in opts.env) {
-			env[key] = opts.env[key];
+		for (var key in process.env) {
+			if (typeof opts.env[key] === "undefined") {
+				opts.env[key] = process.env[key];
+			}
 		}
-		opts.env = env;
 	}
 
 	child = proc.spawn(electron, args.concat(file.path), opts);


### PR DESCRIPTION
When using the `env` option during the electron spawn on linux, electron fails to start. This is due to missing env settings when spawning as the env object is directly overwritten.

This fixes the issue by merging the existing process.env into the passed one.